### PR TITLE
Add month and day to default context

### DIFF
--- a/lib/parsable/context.rb
+++ b/lib/parsable/context.rb
@@ -8,10 +8,10 @@ module Parsable
     attr_accessor :variables
 
     def initialize args={}
-
+      today = Date.today
       @variables = args.fetch(:variables, {
         :random   => OpenStruct.new(:hex => SecureRandom.hex, :integer => Time.now.to_i),
-        :date     => OpenStruct.new(:today => Date.today.to_s, :year => Date.today.year.to_s),
+        :date     => OpenStruct.new(:today => today.to_s, :year => today.year.to_s, :month => sprintf('%02d', today.month), :day => sprintf('%02d', today.day)),
         :time     => OpenStruct.new(:now => Time.now.to_s),
         :custom   => OpenStruct.new
       })

--- a/lib/parsable/remote.rb
+++ b/lib/parsable/remote.rb
@@ -23,7 +23,7 @@ module Parsable
       begin
         Curl::Easy.perform(url) do |http|
           headers.each { |header, value| http.headers[header] = value }
-          http.connect_timeout = 2
+          http.timeout = 2
           http.on_success { |easy| @body = easy.body_str }
         end
       rescue Curl::Err::CurlError

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -5,9 +5,41 @@ describe Parsable::Context do
   let(:context) { Parsable::Context.new }
 
   describe '#new' do
+    subject { context.instance_variable_get('@variables') }
+
     it "sets default variables" do
       keys = %i(random date time custom remote sremote)
-      expect(context.instance_variable_get('@variables').keys).to match_array(keys)
+      expect(subject.keys).to match_array(keys)
+    end
+
+    {
+      '2016-5-6' => {
+        'date.today' => '2016-05-06',
+        'date.year'  => '2016',
+        'date.month' => '05',
+        'date.day'   => '06'
+      },
+      '2016-5-29' => {
+        'date.today' => '2016-05-29',
+        'date.year'  => '2016',
+        'date.month' => '05',
+        'date.day'   => '29'
+      },
+      '2016-12-31' => {
+        'date.today' => '2016-12-31',
+        'date.year'  => '2016',
+        'date.month' => '12',
+        'date.day'   => '31'
+      }
+
+    }.each do |date, examples|
+      examples.each do |var, value|
+        namespace, varname = var.split('.')
+        it "sets #{var}" do
+          allow(Date).to receive(:today).and_return(Date.parse(date))
+          expect(subject[namespace.to_sym].send(varname)).to eq value
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This adds `date.month` and `date.day` to the default context.

Additionally, I changed the remote command to use `timeout` instead of `connect_timeout` as the specs were not passing.  `timeout` will timeout if the response/request cycle is not completed, whereas `connect_timeout` will only timeout will only timeout if the TCP connection is not established.
