### PR TITLE
Make Parsable::Parser#strings public and add specs

### DIFF
--- a/lib/parsable/parser.rb
+++ b/lib/parsable/parser.rb
@@ -21,14 +21,14 @@ module Parsable
       end
     end
 
+    def strings
+      @strings ||= original_string.to_s.scan(REGEX).flatten
+    end
+
     private
 
     def capture string
       [capture_object(string), capture_attribute(string)]
-    end
-
-    def strings
-      @strings ||= original_string.to_s.scan(REGEX).flatten
     end
 
     def capture_object string

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -70,4 +70,50 @@ describe Parsable::Parser do
       end
     end
   end
+
+  describe '#strings' do
+    subject { parser.strings }
+
+    context 'when there are variables' do
+      let(:string) { 'This is a string.' }
+
+      it 'returns an empty array' do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when there is one variable' do
+      context 'at the beginning of the string' do
+        let(:string) { '{{some.variable}} end of string.' }
+
+        it 'finds the variable' do
+          expect(subject).to eq(['some.variable'])
+        end
+      end
+
+      context 'in the middle of the string' do
+        let(:string) { 'Beginning of string {{some.variable}} end of string.' }
+
+        it 'finds the variable' do
+          expect(subject).to eq(['some.variable'])
+        end
+      end
+
+      context 'at the end of the string' do
+        let(:string) { 'Beginning of string {{some.variable}}' }
+
+        it 'finds the variable' do
+          expect(subject).to eq(['some.variable'])
+        end
+      end
+    end
+
+    context 'when there are multiple variables' do
+      let(:string) { '{{foo.bar}} {{foo.baz}}' }
+
+      it 'returns an array of parsed strings' do
+        expect(subject).to match_array(['foo.bar', 'foo.baz'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
@hcliu This is pretty straightforward, but some background might be helpful.  

We want to be able to easily pull out the variables that have been parsed out of a string.  We could use Parsable::Parser#parse to do this, but we would get back an array of Parsable::ParsedItem's which is a clumsier interface for my use case.

Basically the use case is that we want to be able to figure out all of the variables that were used, so we can display them to our user's in some way.
