### PR TITLE
Make random.integer random, not time-based

### DIFF
--- a/lib/parsable/context.rb
+++ b/lib/parsable/context.rb
@@ -9,11 +9,24 @@ module Parsable
 
     def initialize args={}
       today = Date.today
+      time  = Time.now
+
       @variables = args.fetch(:variables, {
-        :random   => OpenStruct.new(:hex => SecureRandom.hex, :integer => Time.now.to_i),
-        :date     => OpenStruct.new(:today => today.to_s, :year => today.year.to_s, :month => sprintf('%02d', today.month), :day => sprintf('%02d', today.day)),
-        :time     => OpenStruct.new(:now => Time.now.to_s),
-        :custom   => OpenStruct.new
+        :random => OpenStruct.new(
+          :hex     => SecureRandom.hex,
+          :integer => time.to_i # TODO: use SecureRandom.random_number
+        ),
+        :date => OpenStruct.new(
+          :today => today.to_s,
+          :year  => today.year.to_s,
+          :month => sprintf('%02d', today.month),
+          :day   => sprintf('%02d', today.day)
+        ),
+        :time => OpenStruct.new(
+          :now   => time.to_s,
+          :epoch => time.to_i
+        ),
+        :custom => OpenStruct.new
       })
 
       @variables.store(:remote, Parsable::Remote.new)

--- a/lib/parsable/context.rb
+++ b/lib/parsable/context.rb
@@ -14,7 +14,7 @@ module Parsable
       @variables = args.fetch(:variables, {
         :random => OpenStruct.new(
           :hex     => SecureRandom.hex,
-          :integer => time.to_i # TODO: use SecureRandom.random_number
+          :integer => SecureRandom.random_number(10_000_000_000) # 10-digit number
         ),
         :date => OpenStruct.new(
           :today => today.to_s,

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -12,32 +12,78 @@ describe Parsable::Context do
       expect(subject.keys).to match_array(keys)
     end
 
-    {
-      '2016-5-6' => {
-        'date.today' => '2016-05-06',
-        'date.year'  => '2016',
-        'date.month' => '05',
-        'date.day'   => '06'
-      },
-      '2016-5-29' => {
-        'date.today' => '2016-05-29',
-        'date.year'  => '2016',
-        'date.month' => '05',
-        'date.day'   => '29'
-      },
-      '2016-12-31' => {
-        'date.today' => '2016-12-31',
-        'date.year'  => '2016',
-        'date.month' => '12',
-        'date.day'   => '31'
-      }
+    context 'date vars' do
+      {
+        '2016-5-6' => {
+          'date.today' => '2016-05-06',
+          'date.year'  => '2016',
+          'date.month' => '05',
+          'date.day'   => '06'
+        },
+        '2016-5-29' => {
+          'date.today' => '2016-05-29',
+          'date.year'  => '2016',
+          'date.month' => '05',
+          'date.day'   => '29'
+        },
+        '2016-12-31' => {
+          'date.today' => '2016-12-31',
+          'date.year'  => '2016',
+          'date.month' => '12',
+          'date.day'   => '31'
+        }
 
-    }.each do |date, examples|
-      examples.each do |var, value|
-        namespace, varname = var.split('.')
-        it "sets #{var}" do
-          allow(Date).to receive(:today).and_return(Date.parse(date))
-          expect(subject[namespace.to_sym].send(varname)).to eq value
+      }.each do |date, examples|
+        examples.each do |var, value|
+          namespace, varname = var.split('.')
+          it "sets #{var}" do
+            allow(Date).to receive(:today).and_return(Date.parse(date))
+            expect(subject[namespace.to_sym].send(varname)).to eq value
+          end
+        end
+      end
+    end
+
+    context 'time vars' do
+      {
+        1275408000 => {
+          'time.now'   => Time.at(1275408000).to_s,
+          'time.epoch' => 1275408000
+        },
+        1475165352 => {
+          'time.now'   => Time.at(1475165352).to_s,
+          'time.epoch' => 1475165352
+        }
+
+      }.each do |time, examples|
+        examples.each do |var, value|
+          namespace, varname = var.split('.')
+          it "sets #{var}" do
+            allow(Time).to receive(:now).and_return(Time.at(time))
+            expect(subject[namespace.to_sym].send(varname)).to eq value
+          end
+        end
+      end
+    end
+
+    context 'random vars' do
+      subject { context.read('random', 'hex') }
+
+      context 'hex' do
+        it 'returns a string' do
+          expect(subject).to be_a String
+        end
+      end
+
+      context 'integer' do
+        subject { context.read('random', 'integer') }
+
+        it 'returns an integer' do
+          expect(subject).to be_an Integer
+        end
+
+        it 'has 10 digits' do
+          expect(subject.to_s.length).to eq 10
         end
       end
     end


### PR DESCRIPTION
Branched off of #7, so will want to get that in then rebase + merge this.

This PR updates the `random.integer` variable to use a random number (instead of epoch time). 

**We may need to consider a migration plan for this if people are using random.integer assuming it's actually epoch time.**
